### PR TITLE
Implement better teleportation

### DIFF
--- a/src/main/java/eu/pb4/graves/config/Config.java
+++ b/src/main/java/eu/pb4/graves/config/Config.java
@@ -68,6 +68,10 @@ public final class Config {
     public final TextNode creationFailedPvPMessage;
     @Nullable
     public final TextNode creationFailedClaimMessage;
+    @Nullable
+    public final TextNode teleportTimerText;
+    @Nullable
+    public final TextNode teleportLocationText;
     public final GravesXPCalculation xpCalc;
 
     public final BlockStyleEntry[] customBlockStateStylesLocked;
@@ -143,6 +147,9 @@ public final class Config {
         this.guiQuickPickupText = parseText(data.guiQuickPickupText);
         this.guiCantReverseAction = parseText(data.guiCantReverseAction);
         this.guiClickToConfirm = parseText(data.guiClickToConfirm);
+
+        this.teleportLocationText = parse(data.teleportLocationText);
+        this.teleportTimerText = parse(data.teleportTimerText);
 
         this.guiInfoIcon = parseItem(data.guiInfoIcon);
         this.guiBarItem = parseItem(data.guiBarItem);

--- a/src/main/java/eu/pb4/graves/config/Config.java
+++ b/src/main/java/eu/pb4/graves/config/Config.java
@@ -342,8 +342,8 @@ public final class Config {
         return texts.toArray(new TextNode[0]);
     }
 
-    public record BlockStyleEntry(BlockState state, BlockEntityType<?> blockEntityType,
-                                  NbtCompound blockEntityNbt) {
+    public static record BlockStyleEntry(BlockState state, BlockEntityType<?> blockEntityType,
+                                         NbtCompound blockEntityNbt) {
     }
 
 }

--- a/src/main/java/eu/pb4/graves/config/Config.java
+++ b/src/main/java/eu/pb4/graves/config/Config.java
@@ -71,6 +71,8 @@ public final class Config {
     @Nullable
     public final TextNode teleportTimerText;
     @Nullable
+    public final TextNode teleportTimerAllowMovingText;
+    @Nullable
     public final TextNode teleportLocationText;
     public final GravesXPCalculation xpCalc;
 
@@ -152,6 +154,7 @@ public final class Config {
 
         this.teleportLocationText = parse(data.teleportLocationText);
         this.teleportTimerText = parse(data.teleportTimerText);
+        this.teleportTimerAllowMovingText = parse(data.teleportTimerTextAllowMoving);
 
         this.teleportCancelledText = parseText(data.teleportCancelledText);
 

--- a/src/main/java/eu/pb4/graves/config/data/ConfigData.java
+++ b/src/main/java/eu/pb4/graves/config/data/ConfigData.java
@@ -39,11 +39,14 @@ public class ConfigData extends VersionedConfigData {
 
     public int protectionTime = 900;
     public int breakingTime = 1800;
+    public int teleportTime = 5;
+    public int invincibleTime = 2;
     public boolean keepBlockAfterBreaking = false;
     public boolean restoreBlockAfterPlayerBreaking = true;
 
     public String xpStorageType = GravesXPCalculation.PERCENT_POINTS.name;
     public double xpPercentTypeValue = 100;
+    public double teleportHeight = 0.5;
 
     public boolean replaceAnyBlock = false;
     public int maxPlacementDistance = 8;
@@ -64,6 +67,9 @@ public class ConfigData extends VersionedConfigData {
     public boolean allowRemoteGraveBreaking = true;
 
     public String graveTitle = "<lang:'text.graves.players_grave':'${player}'>";
+
+    public String teleportTimerText = "<lang:'text.graves.teleport.teleport_timer'>";
+    public String teleportLocationText = "<lang: 'text.graves.teleport.teleport_location'>";
 
     public boolean hologram = true;
     public boolean hologramDisplayIfOnClient = false;

--- a/src/main/java/eu/pb4/graves/config/data/ConfigData.java
+++ b/src/main/java/eu/pb4/graves/config/data/ConfigData.java
@@ -1,8 +1,9 @@
 package eu.pb4.graves.config.data;
 
-import eu.pb4.graves.other.GraveUtils;
 import eu.pb4.graves.other.GravesLookType;
 import eu.pb4.graves.other.GravesXPCalculation;
+import eu.pb4.graves.other.GraveUtils;
+import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.WallBlock;

--- a/src/main/java/eu/pb4/graves/config/data/ConfigData.java
+++ b/src/main/java/eu/pb4/graves/config/data/ConfigData.java
@@ -64,10 +64,12 @@ public class ConfigData extends VersionedConfigData {
     public boolean giveGraveCompass = true;
     public boolean allowRemoteProtectionRemoval = true;
     public boolean allowRemoteGraveBreaking = true;
+    public boolean allowMovingDuringTeleportation = false;
 
     public String graveTitle = "<lang:'text.graves.players_grave':'${player}'>";
 
     public String teleportTimerText = "<lang:'text.graves.teleport.teleport_timer':'${time}'>";
+    public String teleportTimerTextAllowMoving = "<lang:'text.graves.teleport.teleport_timer_moving':'${time}'>";
     public String teleportLocationText = "<lang:'text.graves.teleport.teleport_location':'${position}'>";
     public String teleportCancelledText = "<red><lang:'text.graves.teleport.teleport_cancelled'>";
 

--- a/src/main/java/eu/pb4/graves/ui/GraveListGui.java
+++ b/src/main/java/eu/pb4/graves/ui/GraveListGui.java
@@ -103,6 +103,8 @@ public class GraveListGui extends PagedGui {
                                             if(--teleportTicks >= 0) {
                                                 if(!player.getPos().equals(currentPosition)) {
                                                     player.sendMessage(config.teleportCancelledText);
+                                                    player.playSound(SoundEvents.ENTITY_SHULKER_HURT_CLOSED,
+                                                            SoundCategory.MASTER, 1f, 0.5f);
                                                     return;
                                                 }
                                                 if(teleportTicks == 0) {

--- a/src/main/java/eu/pb4/graves/ui/GraveListGui.java
+++ b/src/main/java/eu/pb4/graves/ui/GraveListGui.java
@@ -21,7 +21,11 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.RegistryKey;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.Objects;
 
 import static eu.pb4.placeholders.api.Placeholders.PREDEFINED_PLACEHOLDER_PATTERN;
 

--- a/src/main/java/eu/pb4/graves/ui/GraveListGui.java
+++ b/src/main/java/eu/pb4/graves/ui/GraveListGui.java
@@ -2,24 +2,29 @@ package eu.pb4.graves.ui;
 
 import com.mojang.authlib.GameProfile;
 import eu.pb4.graves.GraveNetworking;
+import eu.pb4.graves.config.Config;
 import eu.pb4.graves.config.ConfigManager;
+import eu.pb4.graves.config.data.ConfigData;
 import eu.pb4.graves.grave.Grave;
 import eu.pb4.graves.grave.GraveManager;
 import eu.pb4.placeholders.api.Placeholders;
 import eu.pb4.sgui.api.elements.GuiElementBuilder;
 import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.RegistryKey;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 public class GraveListGui extends PagedGui {
     private final UUID targetUUID;
@@ -79,11 +84,22 @@ public class GraveListGui extends PagedGui {
 
                                 var pos = grave.getLocation();
 
-                                ServerWorld world = this.player.getServer().getWorld(RegistryKey.of(Registry.WORLD_KEY, pos.world()));
+                                MinecraftServer server = Objects.requireNonNull(this.player.getServer(), "server; running on client?");
+                                ServerWorld world = server.getWorld(RegistryKey.of(Registry.WORLD_KEY, pos.world()));
                                 if (world != null) {
-                                    this.player.teleport(world, pos.x() + 0.5, pos.y() + 1, pos.z() + 0.5, this.player.getYaw(), this.player.getPitch());
+                                    final ScheduledExecutorService teleportThread = Executors.newScheduledThreadPool(1);
+                                    server.execute(() -> this.player.sendMessage(Text.translatable(config.teleportTimerText), config.configData.teleportTime )));
+                                    teleportThread.schedule(() -> {
+                                        server.execute(() -> this.player.sendMessage(Text.translatable(config.teleportLocationText), pos.x() + ", " + (pos.y()+config.configData.teleportHeight) + ", " + pos.z())));
+                                        this.player.teleport(world, pos.x() + 0.5, pos.y() + 1 + config.configData.teleportHeight, pos.z() + 0.5, this.player.getYaw(), this.player.getPitch());
+                                        server.execute(() -> this.player.playSound(SoundEvents.ENTITY_ENDERMAN_TELEPORT, SoundCategory.MASTER, 1f, 1f));
+                                        server.execute(() -> this.player.setInvulnerable(true));
+                                        teleportThread.schedule(() -> {
+                                            Objects.requireNonNull(this.player.getServer()).execute(() -> player.setInvulnerable(false));
+                                        }, config.configData.invincibleTime, TimeUnit.SECONDS);
+                                    }, config.configData.teleportTime, TimeUnit.SECONDS);
                                 }
-                            }
+                                }
                         } else {
                             this.close();
                             grave.openUi(player, this.canModify);

--- a/src/main/resources/data/universal_graves/lang/en_us.json
+++ b/src/main/resources/data/universal_graves/lang/en_us.json
@@ -35,6 +35,9 @@
   "text.graves.gui.cant_reverse": "You can't reverse this action!",
   "text.graves.gui.click_to_confirm": "Click again to confirm",
 
+  "text.graves.teleport.teleport_timer": "Teleporting in %s seconds",
+  "text.graves.teleport.teleport_location": "Teleporting to %s",
+
   "item.universal_graves.grave_compass": "Grave Compass",
   "block.universal_graves.grave": "Grave",
   "block.universal_graves.visual_grave": "Gravestone",

--- a/src/main/resources/data/universal_graves/lang/en_us.json
+++ b/src/main/resources/data/universal_graves/lang/en_us.json
@@ -35,9 +35,9 @@
   "text.graves.gui.cant_reverse": "You can't reverse this action!",
   "text.graves.gui.click_to_confirm": "Click again to confirm",
 
-  "text.graves.teleport.teleport_timer": "Teleporting in %s seconds",
+  "text.graves.teleport.teleport_timer": "Teleporting in %s seconds, don't move!",
   "text.graves.teleport.teleport_location": "Teleporting to %s",
-  "text.graves.teleport.teleport_cancelled": "Cancelled teleportation.",
+  "text.graves.teleport.teleport_cancelled": "Cancelled teleportation",
 
   "item.universal_graves.grave_compass": "Grave Compass",
   "block.universal_graves.grave": "Grave",

--- a/src/main/resources/data/universal_graves/lang/en_us.json
+++ b/src/main/resources/data/universal_graves/lang/en_us.json
@@ -36,6 +36,7 @@
   "text.graves.gui.click_to_confirm": "Click again to confirm",
 
   "text.graves.teleport.teleport_timer": "Teleporting in %s seconds, don't move!",
+"text.graves.teleport.teleport_timer_moving": "Teleporting in %s seconds",
   "text.graves.teleport.teleport_location": "Teleporting to %s",
   "text.graves.teleport.teleport_cancelled": "Cancelled teleportation",
 

--- a/src/main/resources/data/universal_graves/lang/en_us.json
+++ b/src/main/resources/data/universal_graves/lang/en_us.json
@@ -36,7 +36,7 @@
   "text.graves.gui.click_to_confirm": "Click again to confirm",
 
   "text.graves.teleport.teleport_timer": "Teleporting in %s seconds, don't move!",
-"text.graves.teleport.teleport_timer_moving": "Teleporting in %s seconds",
+  "text.graves.teleport.teleport_timer_moving": "Teleporting in %s seconds",
   "text.graves.teleport.teleport_location": "Teleporting to %s",
   "text.graves.teleport.teleport_cancelled": "Cancelled teleportation",
 


### PR DESCRIPTION
Teleporting is now very customizable:
- Allow for teleportation delay (in seconds)
- Allow for teleportation invulnerability (in seconds)
- Allow for customized teleportation height above the grave
- Allow optional movement prevention when teleporting
- Added noises when teleporting and when movement check fails
- Added customizable chat messages before and when teleporting