### PR TITLE
Fix #universal_graves:replaceable tag

### DIFF
--- a/src/main/resources/data/universal_graves/tags/blocks/replaceable.json
+++ b/src/main/resources/data/universal_graves/tags/blocks/replaceable.json
@@ -4,7 +4,7 @@
     "#minecraft:fire",
 	"#minecraft:flowers",
 	"minecraft:snow",
-	"minecraft:grass",
+	"minecraft:short_grass",
 	"minecraft:tall_grass",
 	"minecraft:seagrass",
 	"minecraft:glow_lichen",


### PR DESCRIPTION
Replace `minecraft:grass` with `minecraft:short_grass`, in accordance with 1.20.3.