### PR TITLE
[1.20.1] Backport Accessories Compatbility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ repositories {
 		url 'https://maven.gegy.dev'
 	}
 
+	maven { url "https://maven.wispforest.io/releases" }
+
 	mavenCentral()
 	mavenLocal()
 }
@@ -67,6 +69,7 @@ dependencies {
 
 	modImplementation include("me.lucko:fabric-permissions-api:0.2-SNAPSHOT")
 
+	modCompileOnly "io.wispforest:accessories-fabric:1.0.0-beta.26+1.20.1"
 	modCompileOnly "dev.emi:trinkets:3.0.4"
 	//modCompileOnly "modrinth.maven:trinkets:3.0.4"
 	modCompileOnly files("modsWithCompat/inventorio-1.17-fabric-1.6.2.jar")

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ fabric_version=0.83.0+1.20.1
 
 
 # Mod Properties
-	mod_version = 3.0.1+1.20.1
+	mod_version = 3.1.0+1.20.1
 	maven_group = eu.pb4
 	archives_base_name = graves
 

--- a/src/main/java/eu/pb4/graves/GravesMod.java
+++ b/src/main/java/eu/pb4/graves/GravesMod.java
@@ -1,10 +1,7 @@
 package eu.pb4.graves;
 
 import eu.pb4.common.protection.api.CommonProtection;
-import eu.pb4.graves.compat.GomlCompat;
-import eu.pb4.graves.compat.InventorioCompat;
-import eu.pb4.graves.compat.SaveGearOnDeathCompat;
-import eu.pb4.graves.compat.TrinketsCompat;
+import eu.pb4.graves.compat.*;
 import eu.pb4.graves.config.ConfigManager;
 import eu.pb4.graves.grave.GraveManager;
 import eu.pb4.graves.other.Commands;
@@ -87,8 +84,11 @@ public class GravesMod implements ModInitializer {
         if (loader.isModLoaded("inventorio")) {
             InventorioCompat.register();
         }
+        if (loader.isModLoaded("accessories")) {
+            AccessoriesCompat.register();
+        }
         if (loader.isModLoaded("trinkets")) {
-            TrinketsCompat.register();
+            TrinketsCompat.register(loader.isModLoaded("tclayer"));
         }
         if (loader.isModLoaded("sgod")) {
             SaveGearOnDeathCompat.register();
@@ -113,7 +113,11 @@ public class GravesMod implements ModInitializer {
             var copied = new ArrayList<>(DO_ON_NEXT_TICK);
             DO_ON_NEXT_TICK.clear();
             for (var c : copied) {
-                c.run();
+                try {
+                    c.run();
+                } catch (Throwable e) {
+                    GravesMod.LOGGER.error("Error occurred while executing delayed task!", e);
+                }
             }
         });
     }

--- a/src/main/java/eu/pb4/graves/compat/AccessoriesCompat.java
+++ b/src/main/java/eu/pb4/graves/compat/AccessoriesCompat.java
@@ -1,0 +1,135 @@
+package eu.pb4.graves.compat;
+
+import eu.pb4.graves.GravesApi;
+import eu.pb4.graves.grave.GraveInventoryMask;
+import eu.pb4.graves.other.VanillaInventoryMask;
+import io.wispforest.accessories.api.AccessoriesAPI;
+import io.wispforest.accessories.api.AccessoriesCapability;
+import io.wispforest.accessories.api.DropRule;
+import io.wispforest.accessories.api.events.OnDropCallback;
+import io.wispforest.accessories.api.slot.SlotReference;
+import io.wispforest.accessories.impl.ExpandedSimpleContainer;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+public class AccessoriesCompat implements GraveInventoryMask {
+    private static final String TYPE_TAG = "Type";
+    private static final String SLOT_TAG = "Slot";
+
+    public static void register() {
+        GravesApi.registerInventoryMask(Identifier.of("universal_graves", "accessories"), new AccessoriesCompat());
+    }
+
+    @Override
+    public void addToGrave(ServerPlayerEntity player, ItemConsumer consumer) {
+        var cap = AccessoriesCapability.get(player);
+        if (cap == null) {
+            return;
+        }
+
+        cap.getContainers().forEach((s, accessoriesContainer) -> {
+            var defRule = accessoriesContainer.slotType() != null ? Objects.requireNonNull(accessoriesContainer.slotType()).dropRule() : DropRule.DEFAULT;
+            addToGrave(player, consumer, s, accessoriesContainer.getAccessories(), "", defRule);
+            addToGrave(player, consumer, s, accessoriesContainer.getCosmeticAccessories(), "cosmetic", defRule);
+        });
+    }
+
+    private void addToGrave(ServerPlayerEntity player, ItemConsumer consumer, String slotName, ExpandedSimpleContainer accessories, String type, DropRule defaultDropRule) {
+        var dmg = player.getRecentDamageSource();
+        if (dmg == null) {
+            dmg = player.getDamageSources().generic();
+        }
+        for (var i = 0; i < accessories.size(); i++) {
+            var stack = accessories.getStack(i);
+            if (stack.isEmpty() || !GravesApi.canAddItem(player, stack)) {
+                return;
+            }
+
+            var ref = SlotReference.of(player, slotName, i);
+
+            var dropRule = AccessoriesAPI.getOrDefaultAccessory(stack).getDropRule(stack, ref, dmg);
+
+            dropRule = OnDropCallback.EVENT.invoker().onDrop(dropRule, stack, ref, dmg);
+
+            if (dropRule == DropRule.DEFAULT) {
+                dropRule = defaultDropRule;
+            }
+
+            if (dropRule == DropRule.DEFAULT) {
+                if (EnchantmentHelper.hasVanishingCurse(stack)) {
+                    dropRule = DropRule.DESTROY;
+                } else {
+                    dropRule = DropRule.DROP;
+                }
+            }
+
+            if (dropRule == DropRule.DROP) {
+                var nbt = new NbtCompound();
+                nbt.putString(TYPE_TAG, type);
+                nbt.putString(SLOT_TAG, slotName);
+
+                consumer.addItem(stack.copy(), i, nbt);
+                accessories.setStack(i, ItemStack.EMPTY);
+            }
+        }
+    }
+
+    @Override
+    public boolean moveToPlayerExactly(ServerPlayerEntity player, ItemStack stack, int slot, NbtElement extraData) {
+        var typeId = ((NbtCompound) extraData).getString(TYPE_TAG);
+        var slotId = ((NbtCompound) extraData).getString(SLOT_TAG);
+
+        var inventory = getInventory(player, typeId, slotId);
+
+        if (inventory != null) {
+            if (inventory.getStack(slot).isEmpty()) {
+                inventory.setStack(slot, stack.copyAndEmpty());
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean moveToPlayerClosest(ServerPlayerEntity player, ItemStack stack, int slot, NbtElement data) {
+        var type = ((NbtCompound) data).getString(TYPE_TAG);
+        var slotId = ((NbtCompound) data).getString(SLOT_TAG);
+
+        var inventory = getInventory(player, type, slotId);
+
+        if (inventory != null) {
+            int size = inventory.size();
+
+            for (int i = 0; i < size; i++) {
+                if (inventory.getStack(i).isEmpty()) {
+                    inventory.setStack(i, stack.copyAndEmpty());
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Nullable
+    private ExpandedSimpleContainer getInventory(ServerPlayerEntity player, String type, String slotId) {
+        var cap = AccessoriesCapability.get(player);
+        if (cap == null) {
+            return null;
+        }
+
+        var slot = cap.getContainers().get(slotId);
+
+        if(slot == null) return null;
+
+        return ("cosmetic".equals(type))
+                ? slot.getCosmeticAccessories()
+                : slot.getAccessories();
+    }
+}

--- a/src/main/java/eu/pb4/graves/compat/TrinketsCompat.java
+++ b/src/main/java/eu/pb4/graves/compat/TrinketsCompat.java
@@ -14,17 +14,20 @@ import net.minecraft.nbt.NbtElement;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 
-public class TrinketsCompat extends VanillaInventoryMask {
-    public static final GraveInventoryMask INSTANCE = new TrinketsCompat();
+public record TrinketsCompat(boolean preventAddition) implements GraveInventoryMask {
     private static final String GROUP_TAG = "Group";
     private static final String SLOT_TAG = "Slot";
 
-    public static void register() {
-        GravesApi.registerInventoryMask(new Identifier("universal_graves", "trinkets"), INSTANCE);
+    public static void register(boolean preventAddition) {
+        GravesApi.registerInventoryMask(new Identifier("universal_graves", "trinkets"), new TrinketsCompat(preventAddition));
     }
 
     @Override
     public void addToGrave(ServerPlayerEntity player, ItemConsumer consumer) {
+        if (preventAddition) {
+            return;
+        }
+
         TrinketsApi.getTrinketComponent(player).ifPresent(trinkets -> trinkets.forEach((ref, stack) -> {
             if (stack.isEmpty() || !GravesApi.canAddItem(player, stack)) {
                 return;
@@ -68,8 +71,7 @@ public class TrinketsCompat extends VanillaInventoryMask {
 
         if (inventory != null) {
             if (inventory.getStack(slot).isEmpty()) {
-                inventory.setStack(slot, stack.copy());
-                stack.setCount(0);
+                inventory.setStack(slot, stack.copyAndEmpty());
                 return true;
             }
         }
@@ -88,8 +90,7 @@ public class TrinketsCompat extends VanillaInventoryMask {
 
             for (int i = 0; i < size; i++) {
                 if (inventory.getStack(i).isEmpty()) {
-                    inventory.setStack(i, stack.copy());
-                    stack.setCount(0);
+                    inventory.setStack(i, stack.copyAndEmpty());
                     return true;
                 }
             }

--- a/src/main/java/eu/pb4/graves/mixin/LivingEntityMixin.java
+++ b/src/main/java/eu/pb4/graves/mixin/LivingEntityMixin.java
@@ -1,9 +1,12 @@
 package eu.pb4.graves.mixin;
 
+import eu.pb4.graves.GravesMod;
 import eu.pb4.graves.other.GraveUtils;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -18,8 +21,10 @@ public abstract class LivingEntityMixin {
         if (((Object) this) instanceof ServerPlayerEntity player) {
             try {
                 GraveUtils.createGrave(player, source);
-            } catch (Exception e) {
-                e.printStackTrace();
+            } catch (Throwable e) {
+                player.sendMessage(Text.literal("Failed to create a grave due to an exception! See logs for more information and report it!").formatted(Formatting.RED));
+                player.sendMessage(Text.literal(e.toString()).formatted(Formatting.RED));
+                GravesMod.LOGGER.error("Failed to create a grave due to an exception!", e);
             }
         }
     }

--- a/src/main/java/eu/pb4/graves/other/GraveUtils.java
+++ b/src/main/java/eu/pb4/graves/other/GraveUtils.java
@@ -331,7 +331,11 @@ public class GraveUtils {
                     List<PositionedItemStack> items = new ArrayList<>();
 
                     for (var mask : GravesApi.getAllInventoryMasks()) {
-                        mask.addToGrave(player, (stack, slot, nbt, tags) -> items.add(new PositionedItemStack(stack, slot, mask, nbt, Set.of(tags))));
+                        try {
+                            mask.addToGrave(player, (stack, slot, nbt, tags) -> items.add(new PositionedItemStack(stack, slot, mask, nbt, Set.of(tags))));
+                        } catch (Throwable e) {
+                            GravesMod.LOGGER.error("Failed to add items from '{}'!", mask.getId(), e);
+                        }
                     }
 
                     int experience = 0;

--- a/src/main/java/eu/pb4/graves/registry/GraveBlock.java
+++ b/src/main/java/eu/pb4/graves/registry/GraveBlock.java
@@ -1,5 +1,6 @@
 package eu.pb4.graves.registry;
 
+import eu.pb4.graves.GravesMod;
 import eu.pb4.graves.config.ConfigManager;
 import eu.pb4.graves.grave.Grave;
 import eu.pb4.graves.other.VisualGraveData;
@@ -72,7 +73,7 @@ public class GraveBlock extends AbstractGraveBlock implements BlockEntityProvide
                     graveBlockEntity.breakBlock();
                 }
             } catch (Exception e) {
-                e.printStackTrace();
+                GravesMod.LOGGER.error("Exception occurred while breaking grave!", e);
             }
         }
         super.onBreak(world, pos, state, player);


### PR DESCRIPTION
Combined with other fixes/adjustments for erroring

The given commit is a backport of https://github.com/Patbox/UniversalGraves/commit/e339e4ca8f29789c259148891e5c57330cbcd973 for 1.20.1

Mainly useful to fix https://github.com/wisp-forest/accessories/issues/78 for 1.20.1