### PR TITLE
Fix Accessories mod items not being stored in graves (1.21.9/1.21.10)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ dependencies {
 
 	modCompileOnly "dev.emi:trinkets:3.10.0"
 	modCompileOnly "maven.modrinth:inventorio:1.10.3+1.20.2"
-	modCompileOnly "io.wispforest:accessories-fabric:1.0.0-beta.11+1.21"
+	modCompileOnly "io.wispforest:accessories-fabric:1.4.0-beta+1.21.10"
 
 	modCompileOnly "maven.modrinth:goml-reserved:1.13.1+1.21"
 	modCompileOnly 'com.jamieswhiteshirt:rtree-3i-lite:0.3.0'

--- a/src/main/java/eu/pb4/graves/compat/AccessoriesCompat.java
+++ b/src/main/java/eu/pb4/graves/compat/AccessoriesCompat.java
@@ -2,22 +2,20 @@ package eu.pb4.graves.compat;
 
 import eu.pb4.graves.GravesApi;
 import eu.pb4.graves.grave.GraveInventoryMask;
-import io.wispforest.accessories.api.*;
+import io.wispforest.accessories.api.AccessoriesCapability;
+import io.wispforest.accessories.api.core.AccessoryRegistry;
+import io.wispforest.accessories.api.events.DropRule;
 import io.wispforest.accessories.api.events.OnDropCallback;
 import io.wispforest.accessories.api.slot.SlotReference;
-import io.wispforest.accessories.impl.ExpandedSimpleContainer;
+import io.wispforest.accessories.impl.core.ExpandedContainer;
 import net.minecraft.component.EnchantmentEffectComponentTypes;
 import net.minecraft.enchantment.EnchantmentHelper;
-import net.minecraft.entity.damage.DamageSource;
-import net.minecraft.inventory.StackReference;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Objects;
 
 public record AccessoriesCompat() implements GraveInventoryMask {
     private static final String TYPE_TAG = "Type";
@@ -35,13 +33,12 @@ public record AccessoriesCompat() implements GraveInventoryMask {
         }
 
         cap.getContainers().forEach((s, accessoriesContainer) -> {
-            var defRule = accessoriesContainer.slotType() != null ? Objects.requireNonNull(accessoriesContainer.slotType()).dropRule() : DropRule.DEFAULT;
-            addToGrave(player, consumer, s, accessoriesContainer.getAccessories(), "", defRule);
-            addToGrave(player, consumer, s, accessoriesContainer.getCosmeticAccessories(), "cosmetic", defRule);
+            addToGrave(player, consumer, s, accessoriesContainer.getAccessories(), "", DropRule.DEFAULT);
+            addToGrave(player, consumer, s, accessoriesContainer.getCosmeticAccessories(), "cosmetic", DropRule.DEFAULT);
         });
     }
 
-    private void addToGrave(ServerPlayerEntity player, ItemConsumer consumer, String slotName, ExpandedSimpleContainer accessories, String type, DropRule defaultDropRule) {
+    private void addToGrave(ServerPlayerEntity player, ItemConsumer consumer, String slotName, ExpandedContainer accessories, String type, DropRule defaultDropRule) {
         var dmg = player.getRecentDamageSource();
         if (dmg == null) {
             dmg = player.getDamageSources().generic();
@@ -49,12 +46,12 @@ public record AccessoriesCompat() implements GraveInventoryMask {
         for (var i = 0; i < accessories.size(); i++) {
             var stack = accessories.getStack(i);
             if (stack.isEmpty() || !GravesApi.canAddItem(player, stack)) {
-                return;
+                continue;
             }
 
             var ref = SlotReference.of(player, slotName, i);
 
-            var dropRule = AccessoriesAPI.getOrDefaultAccessory(stack).getDropRule(stack, ref, dmg);
+            var dropRule = AccessoryRegistry.getAccessoryOrDefault(stack).getDropRule(stack, ref, dmg);
 
             dropRule = OnDropCallback.EVENT.invoker().onDrop(dropRule, stack, ref, dmg);
 
@@ -118,7 +115,7 @@ public record AccessoriesCompat() implements GraveInventoryMask {
     }
 
     @Nullable
-    private ExpandedSimpleContainer getInventory(ServerPlayerEntity player, String type, String slotId) {
+    private ExpandedContainer getInventory(ServerPlayerEntity player, String type, String slotId) {
         var cap = AccessoriesCapability.get(player);
         if (cap == null) {
             return null;


### PR DESCRIPTION
Updates AccessoriesCompat for Accessories 1.4.x API compatibility:

- Changed `return` to `continue` in the addToGrave() loop to prevent early exit when encountering empty slots
- Removed call to slotType().dropRule() (removed in 1.4.x API)
- Updated ExpandedSimpleContainer to ExpandedContainer (moved to impl.core)
- Updated DropRule import (moved to api.events)
- Updated build dependency to accessories-fabric:1.4.0-beta+1.21.10

Fixes https://github.com/Patbox/UniversalGraves/issues/210

Would it be possible to create a 1.21.9 branch so this can be properly targeted? Otherwise, this PR serves as a reference for the backport.