### PR TITLE
Fix Accessories mod items not being stored in graves (1.21.11)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ dependencies {
 
 	modCompileOnly "dev.emi:trinkets:3.10.0"
 	modCompileOnly "maven.modrinth:inventorio:1.10.3+1.20.2"
-	modCompileOnly "io.wispforest:accessories-fabric:1.0.0-beta.11+1.21"
+	modCompileOnly "io.wispforest:accessories-fabric:1.4.0-beta+1.21.10"
 
 	modCompileOnly "maven.modrinth:goml-reserved:1.13.1+1.21"
 	modCompileOnly 'com.jamieswhiteshirt:rtree-3i-lite:0.3.0'

--- a/src/main/java/eu/pb4/graves/compat/AccessoriesCompat.java
+++ b/src/main/java/eu/pb4/graves/compat/AccessoriesCompat.java
@@ -2,13 +2,14 @@ package eu.pb4.graves.compat;
 
 import eu.pb4.graves.GravesApi;
 import eu.pb4.graves.grave.GraveInventoryMask;
-import io.wispforest.accessories.api.*;
+import io.wispforest.accessories.api.AccessoriesCapability;
+import io.wispforest.accessories.api.core.AccessoryRegistry;
+import io.wispforest.accessories.api.events.DropRule;
 import io.wispforest.accessories.api.events.OnDropCallback;
 import io.wispforest.accessories.api.slot.SlotReference;
-import io.wispforest.accessories.impl.ExpandedSimpleContainer;
+import io.wispforest.accessories.impl.core.ExpandedContainer;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Objects;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.resources.Identifier;
@@ -33,13 +34,12 @@ public record AccessoriesCompat() implements GraveInventoryMask {
         }
 
         cap.getContainers().forEach((s, accessoriesContainer) -> {
-            var defRule = accessoriesContainer.slotType() != null ? Objects.requireNonNull(accessoriesContainer.slotType()).dropRule() : DropRule.DEFAULT;
-            addToGrave(player, consumer, s, accessoriesContainer.getAccessories(), "", defRule);
-            addToGrave(player, consumer, s, accessoriesContainer.getCosmeticAccessories(), "cosmetic", defRule);
+            addToGrave(player, consumer, s, accessoriesContainer.getAccessories(), "", DropRule.DEFAULT);
+            addToGrave(player, consumer, s, accessoriesContainer.getCosmeticAccessories(), "cosmetic", DropRule.DEFAULT);
         });
     }
 
-    private void addToGrave(ServerPlayer player, ItemConsumer consumer, String slotName, ExpandedSimpleContainer accessories, String type, DropRule defaultDropRule) {
+    private void addToGrave(ServerPlayer player, ItemConsumer consumer, String slotName, ExpandedContainer accessories, String type, DropRule defaultDropRule) {
         var dmg = player.getLastDamageSource();
         if (dmg == null) {
             dmg = player.damageSources().generic();
@@ -47,12 +47,12 @@ public record AccessoriesCompat() implements GraveInventoryMask {
         for (var i = 0; i < accessories.getContainerSize(); i++) {
             var stack = accessories.getItem(i);
             if (stack.isEmpty() || !GravesApi.canAddItem(player, stack)) {
-                return;
+                continue;
             }
 
             var ref = SlotReference.of(player, slotName, i);
 
-            var dropRule = AccessoriesAPI.getOrDefaultAccessory(stack).getDropRule(stack, ref, dmg);
+            var dropRule = AccessoryRegistry.getAccessoryOrDefault(stack).getDropRule(stack, ref, dmg);
 
             dropRule = OnDropCallback.EVENT.invoker().onDrop(dropRule, stack, ref, dmg);
 
@@ -116,7 +116,7 @@ public record AccessoriesCompat() implements GraveInventoryMask {
     }
 
     @Nullable
-    private ExpandedSimpleContainer getInventory(ServerPlayer player, String type, String slotId) {
+    private ExpandedContainer getInventory(ServerPlayer player, String type, String slotId) {
         var cap = AccessoriesCapability.get(player);
         if (cap == null) {
             return null;


### PR DESCRIPTION
Updates AccessoriesCompat for Accessories 1.4.x API compatibility:

- Changed `return` to `continue` in the addToGrave() loop to prevent early exit when encountering empty slots
- Removed call to slotType().dropRule() (removed in 1.4.x API)
- Updated ExpandedSimpleContainer to ExpandedContainer (moved to impl.core)
- Updated DropRule import (moved to api.events)
- Updated build dependency to accessories-fabric:1.4.0-beta+1.21.10

Fixes https://github.com/Patbox/UniversalGraves/issues/210