### PR TITLE
Add dynamic grave unlock costs and per-player access

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,14 @@ There are few other data types:
     "enchantment_cost_mode": "levels",
     "minimum_cost": 1,
     "owner_multiplier": 1.0,
-    "non_owner_multiplier": 3.0,
-    // Allows a non-owner to pay for individual access while the grave is protected.
-    "allow_non_owner_paid_unlock": true
+    "non_owner_multiplier": 3.0
   }
   ```
   Stack-compatible items are regrouped using their normal maximum stack size. The base cost is
   `max(minimum_cost, floor(equivalent_stacks / stack_divisor) + floor(enchantment_value / enchantment_divisor))`.
-  The applicable multiplier is then applied and rounded up. Dynamic access is recorded per player, and every new
-  quote uses the grave's remaining contents. Existing `free`, `creative`, `item`, and `level` costs retain their
-  global unlock behavior.
+  The applicable multiplier is then applied and rounded down. Every new quote uses the grave's remaining contents.
+  The shared grave model displays the base cost, while the GUI calculates the exact owner/non-owner price for the
+  player opening it.
 * `{/* ITEMSTACK */}` - represents an item.
   Simple format: `"minecraft:skeleton_skull"`
   Full format
@@ -83,7 +81,7 @@ There are few other data types:
 ```json5
 {
   // Config version. Never modify it unless you want to risk data corruption!
-  "config_version": 4,
+  "config_version": 5,
   "protection": {
     // Time grave is protected against other players. Set to -1 to make it infinite. In seconds
     "non_owner_protection_time": 900,
@@ -97,8 +95,11 @@ There are few other data types:
     "use_real_time": false
   },
   "interactions": {
-    // Cost for accessing grave after death, 
+    // Cost for accessing grave after death,
     "unlocking_cost": { /* COST */ },
+    // Allows non-owners to pay the configured unlock cost for their own access while the grave is protected.
+    // When enabled, unlock payment is tracked per player for both static and dynamic costs.
+    "allow_non_owner_paid_unlock": false,
     // Enables giving death compass, which points to player's grave.
     "give_death_compass": true,
     // Makes clicking grave open an ui.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,26 @@ There are few other data types:
     "count": 0
   }
   ```
+  Grave unlocking additionally supports a dynamic level cost calculated from the grave's current contents:
+  ```json5
+  {
+    "type": "dynamic_level",
+    "stack_divisor": 3,
+    "enchantment_divisor": 4,
+    // "levels" sums enchantment levels; "enchanted_stacks" counts enchanted stored stacks.
+    "enchantment_cost_mode": "levels",
+    "minimum_cost": 1,
+    "owner_multiplier": 1.0,
+    "non_owner_multiplier": 3.0,
+    // Allows a non-owner to pay for individual access while the grave is protected.
+    "allow_non_owner_paid_unlock": true
+  }
+  ```
+  Stack-compatible items are regrouped using their normal maximum stack size. The base cost is
+  `max(minimum_cost, floor(equivalent_stacks / stack_divisor) + floor(enchantment_value / enchantment_divisor))`.
+  The applicable multiplier is then applied and rounded up. Dynamic access is recorded per player, and every new
+  quote uses the grave's remaining contents. Existing `free`, `creative`, `item`, and `level` costs retain their
+  global unlock behavior.
 * `{/* ITEMSTACK */}` - represents an item.
   Simple format: `"minecraft:skeleton_skull"`
   Full format
@@ -63,7 +83,7 @@ There are few other data types:
 ```json5
 {
   // Config version. Never modify it unless you want to risk data corruption!
-  "config_version": 3,
+  "config_version": 4,
   "protection": {
     // Time grave is protected against other players. Set to -1 to make it infinite. In seconds
     "non_owner_protection_time": 900,

--- a/build.gradle
+++ b/build.gradle
@@ -78,12 +78,20 @@ dependencies {
 
 	compileOnly "maven.modrinth:goml-reserved:1.20.0+26.1.1"
 	compileOnly 'com.jamieswhiteshirt:rtree-3i-lite:0.3.0'
+
+	testImplementation platform('org.junit:junit-bom:5.12.2')
+	testImplementation 'org.junit.jupiter:junit-jupiter'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	//compileOnly "org.ladysnake.cardinal-components-api:cardinal-components-base:6.1.0"
 
 	//compileOnly("com.terraformersmc:modmenu:7.2.2")
 
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.
+}
+
+test {
+	useJUnitPlatform()
 }
 
 processResources {

--- a/changelog-next
+++ b/changelog-next
@@ -1,1 +1,2 @@
 sabling graves when killed by selected entity.
+- Added dynamic grave unlock costs and optional per-player paid access for non-owners.

--- a/src/main/java/eu/pb4/graves/config/BaseGson.java
+++ b/src/main/java/eu/pb4/graves/config/BaseGson.java
@@ -148,8 +148,7 @@ public class BaseGson {
                     DynamicLevelUnlockCost.EnchantmentCostMode.fromConfig(getString(object, "enchantment_cost_mode", "levels")),
                     getInt(object, "minimum_cost", 1),
                     getDouble(object, "owner_multiplier", 1),
-                    getDouble(object, "non_owner_multiplier", 3),
-                    getBoolean(object, "allow_non_owner_paid_unlock", false)
+                    getDouble(object, "non_owner_multiplier", 3)
             );
         }
 
@@ -168,7 +167,6 @@ public class BaseGson {
             object.addProperty("minimum_cost", dynamicCost.minimumCost());
             object.addProperty("owner_multiplier", dynamicCost.ownerMultiplier());
             object.addProperty("non_owner_multiplier", dynamicCost.nonOwnerMultiplier());
-            object.addProperty("allow_non_owner_paid_unlock", dynamicCost.allowNonOwnerPaidUnlock());
             return object;
         }
 
@@ -178,10 +176,6 @@ public class BaseGson {
 
         private static double getDouble(JsonObject object, String key, double fallback) {
             return object.has(key) ? object.get(key).getAsDouble() : fallback;
-        }
-
-        private static boolean getBoolean(JsonObject object, String key, boolean fallback) {
-            return object.has(key) ? object.get(key).getAsBoolean() : fallback;
         }
 
         private static String getString(JsonObject object, String key, String fallback) {

--- a/src/main/java/eu/pb4/graves/config/BaseGson.java
+++ b/src/main/java/eu/pb4/graves/config/BaseGson.java
@@ -12,8 +12,10 @@ import eu.pb4.graves.config.data.WrappedText;
 import eu.pb4.graves.model.TaggedText;
 import eu.pb4.graves.model.parts.ModelPart;
 import eu.pb4.graves.model.parts.ModelPartType;
-import eu.pb4.graves.other.GravesXPCalculation;
+import eu.pb4.graves.other.DynamicLevelUnlockCost;
 import eu.pb4.graves.other.GenericCost;
+import eu.pb4.graves.other.GraveUnlockCost;
+import eu.pb4.graves.other.GravesXPCalculation;
 import eu.pb4.predicate.api.GsonPredicateSerializer;
 import eu.pb4.predicate.api.MinecraftPredicate;
 import net.minecraft.SharedConstants;
@@ -82,6 +84,7 @@ public class BaseGson {
 
                 .registerTypeHierarchyAdapter(GravesXPCalculation.class, new StringSerializer<>(GravesXPCalculation::byName, GravesXPCalculation::configName))
                 .registerTypeHierarchyAdapter(GenericCost.class, new TeleportationCostSerializer())
+                .registerTypeHierarchyAdapter(GraveUnlockCost.class, new GraveUnlockCostSerializer())
                 .registerTypeHierarchyAdapter(IconData.class, new IconDataSerializer())
                 .registerTypeHierarchyAdapter(WrappedText.class, new StringSerializer<>(WrappedText::of, WrappedText::input))
                 .registerTypeHierarchyAdapter(TaggedText.class, new CodecSerializer<>(TaggedText.CODEC, lookup))
@@ -123,6 +126,66 @@ public class BaseGson {
             obj.addProperty("count", teleportationCost.count());
 
             return obj;
+        }
+    }
+
+    private record GraveUnlockCostSerializer() implements JsonSerializer<GraveUnlockCost>, JsonDeserializer<GraveUnlockCost> {
+        @Override
+        public GraveUnlockCost deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext context) throws JsonParseException {
+            if (!jsonElement.isJsonObject()) {
+                return new GraveUnlockCost.Static(new GenericCost<>(GenericCost.Type.FREE, null, 0));
+            }
+
+            var object = jsonElement.getAsJsonObject();
+            var typeName = object.has("type") ? object.get("type").getAsString() : "creative";
+            if (!typeName.equals("dynamic_level")) {
+                return new GraveUnlockCost.Static(context.deserialize(jsonElement, GenericCost.class));
+            }
+
+            return new DynamicLevelUnlockCost(
+                    getInt(object, "stack_divisor", 3),
+                    getInt(object, "enchantment_divisor", 4),
+                    DynamicLevelUnlockCost.EnchantmentCostMode.fromConfig(getString(object, "enchantment_cost_mode", "levels")),
+                    getInt(object, "minimum_cost", 1),
+                    getDouble(object, "owner_multiplier", 1),
+                    getDouble(object, "non_owner_multiplier", 3),
+                    getBoolean(object, "allow_non_owner_paid_unlock", false)
+            );
+        }
+
+        @Override
+        public JsonElement serialize(GraveUnlockCost cost, Type type, JsonSerializationContext context) {
+            if (cost instanceof GraveUnlockCost.Static staticCost) {
+                return context.serialize(staticCost.cost(), GenericCost.class);
+            }
+
+            var dynamicCost = (DynamicLevelUnlockCost) cost;
+            var object = new JsonObject();
+            object.addProperty("type", "dynamic_level");
+            object.addProperty("stack_divisor", dynamicCost.stackDivisor());
+            object.addProperty("enchantment_divisor", dynamicCost.enchantmentDivisor());
+            object.addProperty("enchantment_cost_mode", dynamicCost.enchantmentCostMode().configName());
+            object.addProperty("minimum_cost", dynamicCost.minimumCost());
+            object.addProperty("owner_multiplier", dynamicCost.ownerMultiplier());
+            object.addProperty("non_owner_multiplier", dynamicCost.nonOwnerMultiplier());
+            object.addProperty("allow_non_owner_paid_unlock", dynamicCost.allowNonOwnerPaidUnlock());
+            return object;
+        }
+
+        private static int getInt(JsonObject object, String key, int fallback) {
+            return object.has(key) ? object.get(key).getAsInt() : fallback;
+        }
+
+        private static double getDouble(JsonObject object, String key, double fallback) {
+            return object.has(key) ? object.get(key).getAsDouble() : fallback;
+        }
+
+        private static boolean getBoolean(JsonObject object, String key, boolean fallback) {
+            return object.has(key) ? object.get(key).getAsBoolean() : fallback;
+        }
+
+        private static String getString(JsonObject object, String key, String fallback) {
+            return object.has(key) ? object.get(key).getAsString() : fallback;
         }
     }
 

--- a/src/main/java/eu/pb4/graves/config/Config.java
+++ b/src/main/java/eu/pb4/graves/config/Config.java
@@ -8,6 +8,7 @@ import eu.pb4.graves.config.data.Variant;
 import eu.pb4.graves.config.data.WrappedDateFormat;
 import eu.pb4.graves.config.data.WrappedText;
 import eu.pb4.graves.other.GenericCost;
+import eu.pb4.graves.other.GraveUnlockCost;
 import eu.pb4.graves.other.GravesXPCalculation;
 import eu.pb4.graves.registry.IconItem;
 import eu.pb4.predicate.api.BuiltinPredicates;
@@ -64,7 +65,7 @@ public class Config {
 
     public static class Interactions {
         @SerializedName("unlocking_cost")
-        public GenericCost<?> cost = new GenericCost<>(GenericCost.Type.FREE, null, 0);
+        public GraveUnlockCost cost = new GraveUnlockCost.Static(new GenericCost<>(GenericCost.Type.FREE, null, 0));
         @SerializedName("give_death_compass")
         public boolean giveGraveCompass = true;
         @SerializedName("enable_use_death_compass_to_open_gui")

--- a/src/main/java/eu/pb4/graves/config/Config.java
+++ b/src/main/java/eu/pb4/graves/config/Config.java
@@ -66,6 +66,8 @@ public class Config {
     public static class Interactions {
         @SerializedName("unlocking_cost")
         public GraveUnlockCost cost = new GraveUnlockCost.Static(new GenericCost<>(GenericCost.Type.FREE, null, 0));
+        @SerializedName("allow_non_owner_paid_unlock")
+        public boolean allowNonOwnerPaidUnlock = false;
         @SerializedName("give_death_compass")
         public boolean giveGraveCompass = true;
         @SerializedName("enable_use_death_compass_to_open_gui")

--- a/src/main/java/eu/pb4/graves/config/ConfigManager.java
+++ b/src/main/java/eu/pb4/graves/config/ConfigManager.java
@@ -15,7 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ConfigManager {
-    public static final int VERSION = 4;
+    public static final int VERSION = 5;
     private static final Path BASE_CONFIG_PATH = FabricLoader.getInstance().getConfigDir().resolve("universal-graves/");
     private static final Path CONFIG_PATH = BASE_CONFIG_PATH.resolve("config.json");
     private static final Path MODELS_PATH = BASE_CONFIG_PATH.resolve("models/");

--- a/src/main/java/eu/pb4/graves/grave/Grave.java
+++ b/src/main/java/eu/pb4/graves/grave/Grave.java
@@ -277,7 +277,7 @@ public final class Grave {
         values.put("creation_date", Component.literal(config.texts.fullDateFormat.format().format(new Date(this.creationTime * 1000))));
         values.put("since_creation", Component.literal(config.getFormattedTime(System.currentTimeMillis() / 1000 - this.creationTime)));
         values.put("id", Component.literal("" + this.id));
-        values.put("cost", config.interactions.cost.quote(this, true).toText());
+        values.put("cost", config.interactions.cost.baseQuote(this).toText());
         return values;
     }
 
@@ -360,8 +360,8 @@ public final class Grave {
             return false;
         }
 
-        var cost = ConfigManager.getConfig().interactions.cost;
-        return this.hasProtectionAccess(player) || (cost.unlocksPerPlayer() && cost.allowsNonOwnerPayment());
+        var interactions = ConfigManager.getConfig().interactions;
+        return this.hasProtectionAccess(player) || interactions.allowNonOwnerPaidUnlock;
     }
 
     public GenericCost<?> getUnlockCost(ServerPlayer player) {
@@ -379,7 +379,7 @@ public final class Grave {
 
         var cost = cfg.interactions.cost.quote(this, player);
         if (cost.takeCost(player)) {
-            if (cfg.interactions.cost.unlocksPerPlayer()) {
+            if (cfg.interactions.allowNonOwnerPaidUnlock) {
                 this.paidUnlockUUIDs.add(player.getUUID());
             } else {
                 this.requirePayment = false;

--- a/src/main/java/eu/pb4/graves/grave/Grave.java
+++ b/src/main/java/eu/pb4/graves/grave/Grave.java
@@ -56,6 +56,7 @@ public final class Grave {
     private int itemCount;
     private Component deathCause;
     private final Set<UUID> allowedUUIDs;
+    private final Set<UUID> paidUnlockUUIDs;
     private final NonNullList<PositionedItemStack> items;
     private Location location;
     private GraveType type;
@@ -74,13 +75,14 @@ public final class Grave {
     private boolean delayPlayerModel = false;
 
     public Grave() {
-        this.requirePayment = !ConfigManager.getConfig().interactions.cost.isFree();
+        this.requirePayment = ConfigManager.getConfig().interactions.cost.requiresPayment();
         this.gameProfile = DEFAULT_GAME_PROFILE;
         this.creationTime = Long.MAX_VALUE;
         this.xp = 0;
         this.itemCount = 0;
         this.deathCause = DEFAULT_DEATH_CAUSE;
         this.allowedUUIDs = new HashSet<>();
+        this.paidUnlockUUIDs = new HashSet<>();
         this.items = NonNullList.create();
         this.type = GraveType.VIRTUAL;
         this.location = new Location(ServerLevel.OVERWORLD.identifier(), BlockPos.ZERO);
@@ -91,7 +93,7 @@ public final class Grave {
     }
 
     public Grave(long id, @Nullable GameProfile profile, byte visibleLayers, HumanoidArm arm, BlockPos position, Identifier world, GraveType type, long creationTime, long gameCreationTime, int xp, Component deathCause, Collection<UUID> allowedUUIDs, Collection<PositionedItemStack> itemStacks, boolean isProtectionEnabled, int minecraftDay) {
-        this.requirePayment = !ConfigManager.getConfig().interactions.cost.isFree();
+        this.requirePayment = ConfigManager.getConfig().interactions.cost.requiresPayment();
         this.gameProfile = profile;
         this.creationTime = creationTime;
         this.gameCreationTime = gameCreationTime;
@@ -99,6 +101,7 @@ public final class Grave {
         this.xp = xp;
         this.deathCause = deathCause;
         this.allowedUUIDs = new HashSet<>(allowedUUIDs);
+        this.paidUnlockUUIDs = new HashSet<>();
         this.location = new Location(world, position);
         this.items = NonNullList.of(PositionedItemStack.EMPTY, itemStacks.toArray(new PositionedItemStack[0]));
         this.utilProtectionChangeMessage = !this.isProtected();
@@ -168,6 +171,12 @@ public final class Grave {
 
         nbt.put("AllowedUUIDs", allowedUUIDs);
 
+        var paidUnlockUUIDs = new ListTag();
+        for (var uuid : this.paidUnlockUUIDs) {
+            paidUnlockUUIDs.add(UUIDUtil.LENIENT_CODEC.encodeStart(NbtOps.INSTANCE, uuid).getOrThrow());
+        }
+        nbt.put("PaidUnlockUUIDs", paidUnlockUUIDs);
+
         var items = new ListTag();
         for (var item : this.items) {
             items.add(item.toNbt(lookup));
@@ -195,6 +204,7 @@ public final class Grave {
             this.deathCause = BaseGson.text(lookup).fromJson(nbt.getStringOr("DeathCause", ""));
             this.location = Location.readData(nbt);
             this.allowedUUIDs.clear();
+            this.paidUnlockUUIDs.clear();
             this.requirePayment = nbt.getBooleanOr("RequirePayment", false);
 
             if (nbt.contains("Type")) {
@@ -217,6 +227,9 @@ public final class Grave {
 
             for (var nbtUUID : nbt.getListOrEmpty("AllowedUUIDs")) {
                 this.allowedUUIDs.add(UUIDUtil.AUTHLIB_CODEC.decode(NbtOps.INSTANCE, nbtUUID).getOrThrow().getFirst());
+            }
+            for (var nbtUUID : nbt.getListOrEmpty("PaidUnlockUUIDs")) {
+                this.paidUnlockUUIDs.add(UUIDUtil.AUTHLIB_CODEC.decode(NbtOps.INSTANCE, nbtUUID).getOrThrow().getFirst());
             }
 
             for (var item : nbt.getListOrEmpty("Items")) {
@@ -264,7 +277,7 @@ public final class Grave {
         values.put("creation_date", Component.literal(config.texts.fullDateFormat.format().format(new Date(this.creationTime * 1000))));
         values.put("since_creation", Component.literal(config.getFormattedTime(System.currentTimeMillis() / 1000 - this.creationTime)));
         values.put("id", Component.literal("" + this.id));
-        values.put("cost", config.interactions.cost.toText());
+        values.put("cost", config.interactions.cost.quote(this, true).toText());
         return values;
     }
 
@@ -307,11 +320,11 @@ public final class Grave {
     }
 
     public boolean canTakeFrom(GameProfile profile) {
-        return !this.requirePayment && this.hasAccess(profile);
+        return !this.isPaymentRequired(profile.id()) && this.hasAccess(profile);
     }
 
     public boolean canTakeFrom(NameAndId profile) {
-        return !this.requirePayment && this.hasAccess(profile);
+        return !this.isPaymentRequired(profile.id()) && this.hasAccess(profile);
     }
 
     public boolean canTakeFrom(Player entity) {
@@ -323,35 +336,66 @@ public final class Grave {
     }
 
     public boolean hasAccess(GameProfile profile) {
-        return !this.isProtected() || (this.gameProfile != null && this.gameProfile.id().equals(profile.id())) || this.allowedUUIDs.contains(profile.id());
+        return this.hasProtectionAccess(profile) || this.paidUnlockUUIDs.contains(profile.id());
     }
 
     public boolean hasAccess(NameAndId profile) {
+        return this.hasProtectionAccess(profile) || this.paidUnlockUUIDs.contains(profile.id());
+    }
+
+    public boolean hasProtectionAccess(Player entity) {
+        return this.hasProtectionAccess(entity.getGameProfile()) || (entity.isCreative() && FabricPermissionBridge.checkPermission(entity.createCommandSourceStackForNameResolution((ServerLevel) entity.level()), id("can_open_others"), PermissionLevel.ADMINS));
+    }
+
+    public boolean hasProtectionAccess(GameProfile profile) {
         return !this.isProtected() || (this.gameProfile != null && this.gameProfile.id().equals(profile.id())) || this.allowedUUIDs.contains(profile.id());
+    }
+
+    public boolean hasProtectionAccess(NameAndId profile) {
+        return !this.isProtected() || (this.gameProfile != null && this.gameProfile.id().equals(profile.id())) || this.allowedUUIDs.contains(profile.id());
+    }
+
+    public boolean canPayForUnlock(ServerPlayer player) {
+        if (!this.isPaymentRequired(player)) {
+            return false;
+        }
+
+        var cost = ConfigManager.getConfig().interactions.cost;
+        return this.hasProtectionAccess(player) || (cost.unlocksPerPlayer() && cost.allowsNonOwnerPayment());
+    }
+
+    public GenericCost<?> getUnlockCost(ServerPlayer player) {
+        return ConfigManager.getConfig().interactions.cost.quote(this, player);
     }
 
     public boolean payForUnlock(ServerPlayer player) {
         var cfg = ConfigManager.getConfig();
-        if (!hasAccess(player.getGameProfile())) {
+        if (!this.canPayForUnlock(player)) {
             if (!cfg.texts.cantPayForThisGrave.isEmpty()) {
                 player.sendSystemMessage(cfg.texts.cantPayForThisGrave.text());
             }
             return false;
         }
 
-        if (cfg.interactions.cost.checkCost(player)) {
-            cfg.interactions.cost.takeCost(player);
-            this.requirePayment = false;
-            if (!cfg.texts.graveUnlocked.isEmpty()) {
-                player.sendSystemMessage(cfg.texts.graveUnlocked.with(cfg.interactions.cost.getPlaceholders()));
+        var cost = cfg.interactions.cost.quote(this, player);
+        if (cost.takeCost(player)) {
+            if (cfg.interactions.cost.unlocksPerPlayer()) {
+                this.paidUnlockUUIDs.add(player.getUUID());
+            } else {
+                this.requirePayment = false;
             }
-            if (player.level().getServer().getLevel(ResourceKey.create(Registries.DIMENSION, this.location.world())).getBlockEntity(location.blockPos()) instanceof GraveBlockEntity entity) {
+            GraveManager.INSTANCE.setDirty();
+            if (!cfg.texts.graveUnlocked.isEmpty()) {
+                player.sendSystemMessage(cfg.texts.graveUnlocked.with(cost.getPlaceholders()));
+            }
+            var world = player.level().getServer().getLevel(ResourceKey.create(Registries.DIMENSION, this.location.world()));
+            if (world != null && world.getBlockEntity(location.blockPos()) instanceof GraveBlockEntity entity) {
                 entity.setModelId(entity.getGraveModelId());
             }
 
             return true;
         }
-        player.sendSystemMessage(cfg.texts.graveNotEnoughCost.with(cfg.interactions.cost.getPlaceholders()));
+        player.sendSystemMessage(cfg.texts.graveNotEnoughCost.with(cost.getPlaceholders()));
 
         return false;
     }
@@ -504,6 +548,14 @@ public final class Grave {
         return this.requirePayment;
     }
 
+    public boolean isPaymentRequired(ServerPlayer player) {
+        return this.isPaymentRequired(player.getUUID());
+    }
+
+    private boolean isPaymentRequired(UUID uuid) {
+        return this.requirePayment && !this.paidUnlockUUIDs.contains(uuid);
+    }
+
     public byte visibleSkinModelParts() {
         return skinModelParts;
     }
@@ -611,7 +663,7 @@ public final class Grave {
     public void quickEquip(ServerPlayer player) {
         try {
             if (player.isAlive() && this.hasAccess(player)) {
-                if (this.requirePayment && !this.payForUnlock(player)) {
+                if (this.isPaymentRequired(player) && !this.payForUnlock(player)) {
                     return;
                 }
 

--- a/src/main/java/eu/pb4/graves/other/DynamicLevelUnlockCost.java
+++ b/src/main/java/eu/pb4/graves/other/DynamicLevelUnlockCost.java
@@ -18,8 +18,7 @@ public record DynamicLevelUnlockCost(
         EnchantmentCostMode enchantmentCostMode,
         int minimumCost,
         double ownerMultiplier,
-        double nonOwnerMultiplier,
-        boolean allowNonOwnerPaidUnlock
+        double nonOwnerMultiplier
 ) implements GraveUnlockCost {
     public DynamicLevelUnlockCost {
         stackDivisor = Math.max(1, stackDivisor);
@@ -37,27 +36,29 @@ public record DynamicLevelUnlockCost(
         return new GenericCost<>(GenericCost.Type.LEVEL, null, this.calculateFinalCost(equivalentStacks, enchantmentValue, owner));
     }
 
-    int calculateFinalCost(long equivalentStacks, long enchantmentValue, boolean owner) {
+    @Override
+    public GenericCost<?> baseQuote(Grave grave) {
+        long equivalentStacks = this.countEquivalentStacks(grave.getItems());
+        long enchantmentValue = this.countEnchantmentValue(grave.getItems());
+        return new GenericCost<>(GenericCost.Type.LEVEL, null, this.calculateBaseCost(equivalentStacks, enchantmentValue));
+    }
+
+    int calculateBaseCost(long equivalentStacks, long enchantmentValue) {
         long stackCost = equivalentStacks / this.stackDivisor;
         long enchantmentCost = enchantmentValue / this.enchantmentDivisor;
         long baseCost = Math.max(this.minimumCost, saturatedAdd(stackCost, enchantmentCost));
+        return clampToInt(baseCost);
+    }
+
+    int calculateFinalCost(long equivalentStacks, long enchantmentValue, boolean owner) {
+        int baseCost = this.calculateBaseCost(equivalentStacks, enchantmentValue);
         double multiplier = owner ? this.ownerMultiplier : this.nonOwnerMultiplier;
-        return ceilAndClamp(baseCost * multiplier);
+        return floorAndClamp(baseCost * multiplier);
     }
 
     @Override
     public boolean requiresPayment() {
         return true;
-    }
-
-    @Override
-    public boolean unlocksPerPlayer() {
-        return true;
-    }
-
-    @Override
-    public boolean allowsNonOwnerPayment() {
-        return this.allowNonOwnerPaidUnlock;
     }
 
     long countEquivalentStacks(Iterable<? extends PositionedItemStack> items) {
@@ -138,14 +139,24 @@ public record DynamicLevelUnlockCost(
         return first + second;
     }
 
-    private static int ceilAndClamp(double value) {
+    private static int clampToInt(long value) {
+        if (value <= 0) {
+            return 0;
+        }
+        if (value >= Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return (int) value;
+    }
+
+    private static int floorAndClamp(double value) {
         if (Double.isNaN(value) || value <= 0) {
             return 0;
         }
         if (value >= Integer.MAX_VALUE) {
             return Integer.MAX_VALUE;
         }
-        return (int) Math.ceil(value);
+        return (int) Math.floor(value);
     }
 
     private static final class StackGroup<T> {

--- a/src/main/java/eu/pb4/graves/other/DynamicLevelUnlockCost.java
+++ b/src/main/java/eu/pb4/graves/other/DynamicLevelUnlockCost.java
@@ -1,0 +1,181 @@
+package eu.pb4.graves.other;
+
+import eu.pb4.graves.grave.Grave;
+import eu.pb4.graves.grave.PositionedItemStack;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.BiPredicate;
+import java.util.function.ToIntFunction;
+import java.util.function.ToLongFunction;
+
+public record DynamicLevelUnlockCost(
+        int stackDivisor,
+        int enchantmentDivisor,
+        EnchantmentCostMode enchantmentCostMode,
+        int minimumCost,
+        double ownerMultiplier,
+        double nonOwnerMultiplier,
+        boolean allowNonOwnerPaidUnlock
+) implements GraveUnlockCost {
+    public DynamicLevelUnlockCost {
+        stackDivisor = Math.max(1, stackDivisor);
+        enchantmentDivisor = Math.max(1, enchantmentDivisor);
+        enchantmentCostMode = enchantmentCostMode != null ? enchantmentCostMode : EnchantmentCostMode.LEVELS;
+        minimumCost = Math.max(0, minimumCost);
+        ownerMultiplier = sanitizeMultiplier(ownerMultiplier);
+        nonOwnerMultiplier = sanitizeMultiplier(nonOwnerMultiplier);
+    }
+
+    @Override
+    public GenericCost<?> quote(Grave grave, boolean owner) {
+        long equivalentStacks = this.countEquivalentStacks(grave.getItems());
+        long enchantmentValue = this.countEnchantmentValue(grave.getItems());
+        return new GenericCost<>(GenericCost.Type.LEVEL, null, this.calculateFinalCost(equivalentStacks, enchantmentValue, owner));
+    }
+
+    int calculateFinalCost(long equivalentStacks, long enchantmentValue, boolean owner) {
+        long stackCost = equivalentStacks / this.stackDivisor;
+        long enchantmentCost = enchantmentValue / this.enchantmentDivisor;
+        long baseCost = Math.max(this.minimumCost, saturatedAdd(stackCost, enchantmentCost));
+        double multiplier = owner ? this.ownerMultiplier : this.nonOwnerMultiplier;
+        return ceilAndClamp(baseCost * multiplier);
+    }
+
+    @Override
+    public boolean requiresPayment() {
+        return true;
+    }
+
+    @Override
+    public boolean unlocksPerPlayer() {
+        return true;
+    }
+
+    @Override
+    public boolean allowsNonOwnerPayment() {
+        return this.allowNonOwnerPaidUnlock;
+    }
+
+    long countEquivalentStacks(Iterable<? extends PositionedItemStack> items) {
+        return countEquivalentStacks(
+                items,
+                positionedStack -> positionedStack.stack().getCount(),
+                positionedStack -> positionedStack.stack().getMaxStackSize(),
+                (first, second) -> ItemStack.isSameItemSameComponents(first.stack(), second.stack())
+        );
+    }
+
+    static <T> long countEquivalentStacks(Iterable<T> items, ToLongFunction<T> count, ToIntFunction<T> maxStackSize,
+                                          BiPredicate<T, T> compatible) {
+        List<StackGroup<T>> groups = new ArrayList<>();
+
+        for (var item : items) {
+            long itemCount = count.applyAsLong(item);
+            if (itemCount <= 0) {
+                continue;
+            }
+
+            StackGroup<T> matchingGroup = null;
+            for (var group : groups) {
+                if (compatible.test(group.representative, item)) {
+                    matchingGroup = group;
+                    break;
+                }
+            }
+
+            if (matchingGroup == null) {
+                groups.add(new StackGroup<>(item, itemCount));
+            } else {
+                matchingGroup.count = saturatedAdd(matchingGroup.count, itemCount);
+            }
+        }
+
+        long result = 0;
+        for (var group : groups) {
+            int groupMaxStackSize = Math.max(1, maxStackSize.applyAsInt(group.representative));
+            long equivalentCount = 1 + (group.count - 1) / groupMaxStackSize;
+            result = saturatedAdd(result, equivalentCount);
+        }
+        return result;
+    }
+
+    long countEnchantmentValue(Iterable<? extends PositionedItemStack> items) {
+        long result = 0;
+
+        for (var positionedStack : items) {
+            var stack = positionedStack.stack();
+            if (stack.isEmpty()) {
+                continue;
+            }
+
+            var enchantments = EnchantmentHelper.getEnchantmentsForCrafting(stack);
+            if (this.enchantmentCostMode == EnchantmentCostMode.ENCHANTED_STACKS) {
+                if (!enchantments.isEmpty()) {
+                    result = saturatedAdd(result, 1);
+                }
+            } else {
+                for (var entry : enchantments.entrySet()) {
+                    result = saturatedAdd(result, entry.getIntValue());
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static double sanitizeMultiplier(double multiplier) {
+        return Double.isFinite(multiplier) ? Math.max(0, multiplier) : 0;
+    }
+
+    private static long saturatedAdd(long first, long second) {
+        if (Long.MAX_VALUE - first < second) {
+            return Long.MAX_VALUE;
+        }
+        return first + second;
+    }
+
+    private static int ceilAndClamp(double value) {
+        if (Double.isNaN(value) || value <= 0) {
+            return 0;
+        }
+        if (value >= Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return (int) Math.ceil(value);
+    }
+
+    private static final class StackGroup<T> {
+        private final T representative;
+        private long count;
+
+        private StackGroup(T representative, long count) {
+            this.representative = representative;
+            this.count = count;
+        }
+    }
+
+    public enum EnchantmentCostMode {
+        LEVELS,
+        ENCHANTED_STACKS;
+
+        public static EnchantmentCostMode fromConfig(String value) {
+            if (value == null) {
+                return LEVELS;
+            }
+
+            try {
+                return valueOf(value.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException exception) {
+                return LEVELS;
+            }
+        }
+
+        public String configName() {
+            return this.name().toLowerCase(Locale.ROOT);
+        }
+    }
+}

--- a/src/main/java/eu/pb4/graves/other/GraveUnlockCost.java
+++ b/src/main/java/eu/pb4/graves/other/GraveUnlockCost.java
@@ -10,19 +10,20 @@ public interface GraveUnlockCost {
         return this.quote(grave, grave.isOwner(player));
     }
 
+    default GenericCost<?> baseQuote(Grave grave) {
+        return this.quote(grave, true);
+    }
+
     boolean requiresPayment();
-
-    default boolean unlocksPerPlayer() {
-        return false;
-    }
-
-    default boolean allowsNonOwnerPayment() {
-        return false;
-    }
 
     record Static(GenericCost<?> cost) implements GraveUnlockCost {
         @Override
         public GenericCost<?> quote(Grave grave, boolean owner) {
+            return this.cost;
+        }
+
+        @Override
+        public GenericCost<?> baseQuote(Grave grave) {
             return this.cost;
         }
 

--- a/src/main/java/eu/pb4/graves/other/GraveUnlockCost.java
+++ b/src/main/java/eu/pb4/graves/other/GraveUnlockCost.java
@@ -1,0 +1,34 @@
+package eu.pb4.graves.other;
+
+import eu.pb4.graves.grave.Grave;
+import net.minecraft.server.level.ServerPlayer;
+
+public interface GraveUnlockCost {
+    GenericCost<?> quote(Grave grave, boolean owner);
+
+    default GenericCost<?> quote(Grave grave, ServerPlayer player) {
+        return this.quote(grave, grave.isOwner(player));
+    }
+
+    boolean requiresPayment();
+
+    default boolean unlocksPerPlayer() {
+        return false;
+    }
+
+    default boolean allowsNonOwnerPayment() {
+        return false;
+    }
+
+    record Static(GenericCost<?> cost) implements GraveUnlockCost {
+        @Override
+        public GenericCost<?> quote(Grave grave, boolean owner) {
+            return this.cost;
+        }
+
+        @Override
+        public boolean requiresPayment() {
+            return !this.cost.isFree();
+        }
+    }
+}

--- a/src/main/java/eu/pb4/graves/registry/GraveBlock.java
+++ b/src/main/java/eu/pb4/graves/registry/GraveBlock.java
@@ -78,14 +78,17 @@ public class GraveBlock extends AbstractGraveBlock implements EntityBlock {
             return InteractionResult.PASS;
         }
 
-        if (blockEntity instanceof GraveBlockEntity graveBlockEntity && graveBlockEntity.getGrave() != null && graveBlockEntity.getGrave().hasAccess(player)) {
+        if (blockEntity instanceof GraveBlockEntity graveBlockEntity && graveBlockEntity.getGrave() != null
+                && (graveBlockEntity.getGrave().hasAccess(player) || graveBlockEntity.getGrave().canPayForUnlock(player))) {
             try {
                 var grave = graveBlockEntity.getGrave();
 
                 grave.updateSelf(world.getServer());
 
                 if (!grave.isRemoved()) {
-                    if (ConfigManager.getConfig().interactions.shiftClickTakesItems && (player.isShiftKeyDown() || !ConfigManager.getConfig().interactions.clickGraveToOpenGui)) {
+                    if ((grave.canTakeFrom(player) || grave.hasProtectionAccess(player))
+                            && ConfigManager.getConfig().interactions.shiftClickTakesItems
+                            && (player.isShiftKeyDown() || !ConfigManager.getConfig().interactions.clickGraveToOpenGui)) {
                         grave.quickEquip(player);
                     } else if (!player.isShiftKeyDown()) {
                         grave.openUi(player, true, false);

--- a/src/main/java/eu/pb4/graves/ui/GraveGui.java
+++ b/src/main/java/eu/pb4/graves/ui/GraveGui.java
@@ -23,7 +23,7 @@ public class GraveGui extends PagedGui {
     private final GuiLike previousUi;
     private final boolean canModify;
     private final boolean canTeleport;
-    private final boolean hasAccess;
+    private final boolean hasProtectionAccess;
     private int ticker = 0;
     private int actionTimeRemoveProtect = -1;
     private int actionTimeFetch = -1;
@@ -34,7 +34,7 @@ public class GraveGui extends PagedGui {
         this.grave = grave;
         this.canModify = canModify;
         this.canTeleport = ConfigManager.getConfig().teleportation.cost.type() != GenericCost.Type.CREATIVE || player.isCreative();
-        this.hasAccess = grave.hasAccess(player);
+        this.hasProtectionAccess = grave.hasProtectionAccess(player);
         this.canTake = grave.canTakeFrom(player);
         this.canFetch = canFetch;
         this.setTitle(ConfigManager.getConfig().ui.graveTitle.with(grave.getPlaceholders(player.level().getServer())));
@@ -175,9 +175,11 @@ public class GraveGui extends PagedGui {
 
     private GuiSlot getUnlockGrave() {
         var config = ConfigManager.getConfig();
-        if (this.grave.isPaymentRequired() && (config.interactions.allowRemoteGraveUnlocking || FabricPermissionBridge.checkPermission(player, id("can_unlock_remotely"), PermissionLevel.ADMINS))) {
-            return GuiSlot.of(ConfigManager.getConfig().ui.unlockButton.get(config.interactions.cost.checkCost(player))
-                    .builder(ConfigManager.getConfig().interactions.cost.getPlaceholders())
+        if (this.grave.isPaymentRequired(player) && this.grave.canPayForUnlock(player)
+                && (this.canModify || config.interactions.allowRemoteGraveUnlocking || FabricPermissionBridge.checkPermission(player, id("can_unlock_remotely"), PermissionLevel.ADMINS))) {
+            var cost = this.grave.getUnlockCost(player);
+            return GuiSlot.of(ConfigManager.getConfig().ui.unlockButton.get(cost.checkCost(player))
+                    .builder(cost.getPlaceholders())
                     .setCallback(() -> {
                         if (this.grave.payForUnlock(player)) {
                             this.canTake = this.grave.canTakeFrom(player);
@@ -194,7 +196,7 @@ public class GraveGui extends PagedGui {
 
     private GuiSlot getRemoveProtection() {
         var config = ConfigManager.getConfig();
-        if (this.grave.isProtected() && (this.hasAccess && (config.interactions.allowRemoteProtectionRemoval || FabricPermissionBridge.checkPermission(player, id("can_remove_protection_remotely"), PermissionLevel.ADMINS)))) {
+        if (this.grave.isProtected() && (this.hasProtectionAccess && (config.interactions.allowRemoteProtectionRemoval || FabricPermissionBridge.checkPermission(player, id("can_remove_protection_remotely"), PermissionLevel.ADMINS)))) {
             if (this.actionTimeRemoveProtect != -1) {
                 return GuiSlot.of(config.ui.removeProtectionButton.get(false).builder()
                         .setCallback(() -> {
@@ -215,7 +217,8 @@ public class GraveGui extends PagedGui {
             }
         }
 
-        if (this.canModify || (this.canTake && (config.interactions.allowRemoteGraveBreaking || FabricPermissionBridge.checkPermission(player, id("can_break_remotely"), PermissionLevel.ADMINS)))) {
+        if (this.canTake && (this.canModify || config.interactions.allowRemoteGraveBreaking
+                || FabricPermissionBridge.checkPermission(player, id("can_break_remotely"), PermissionLevel.ADMINS))) {
             if (this.actionTimeRemoveProtect != -1) {
                 return GuiSlot.of(config.ui.breakGraveButton.get(false).builder()
                         .setCallback(() -> {

--- a/src/main/java/eu/pb4/graves/ui/GraveGui.java
+++ b/src/main/java/eu/pb4/graves/ui/GraveGui.java
@@ -196,7 +196,11 @@ public class GraveGui extends PagedGui {
 
     private GuiSlot getRemoveProtection() {
         var config = ConfigManager.getConfig();
-        if (this.grave.isProtected() && (this.hasProtectionAccess && (config.interactions.allowRemoteProtectionRemoval || FabricPermissionBridge.checkPermission(player, id("can_remove_protection_remotely"), PermissionLevel.ADMINS)))) {
+        if (!config.interactions.allowNonOwnerPaidUnlock
+                && this.grave.isProtected()
+                && this.hasProtectionAccess
+                && (config.interactions.allowRemoteProtectionRemoval
+                || FabricPermissionBridge.checkPermission(player, id("can_remove_protection_remotely"), PermissionLevel.ADMINS))) {
             if (this.actionTimeRemoveProtect != -1) {
                 return GuiSlot.of(config.ui.removeProtectionButton.get(false).builder()
                         .setCallback(() -> {

--- a/src/main/resources/data/universal_graves/lang/en_us.json
+++ b/src/main/resources/data/universal_graves/lang/en_us.json
@@ -19,9 +19,9 @@
   "text.graves.creation_failed_void": "Grave wasn't created, because you died in void!",
   "text.graves.creation_failed_pvp": "Grave wasn't created, because player killed you! Your items were dropped at %s (%s)",
   "text.graves.creation_failed_claim": "Grave wasn't created, because you were in a claim! Your items were dropped at %s (%s)",
-  "text.graves.grave_unlock_payment.no_access": "You don't have access to this grave!",
-  "text.graves.grave_unlock_payment.accepted": "You have unlocked the grave!",
-  "text.graves.grave_unlock_payment.failed": "You don't have enough currency to unlock the grave! Required: %s",
+  "text.graves.grave_unlock_payment.no_access": "You cannot pay for access to this grave!",
+  "text.graves.grave_unlock_payment.accepted": "You have paid for access to the grave!",
+  "text.graves.grave_unlock_payment.failed": "You don't have enough resources to access the grave! Required: %s",
 
   "text.graves.damage_source_info": "You were damaged by: %s",
   "text.graves.damage_source_info.enabled": "Enabled displaying of next damage sources! Type this command again to disable.",
@@ -39,7 +39,7 @@
   "text.graves.gui.cost.not_enough": "Not enough resources!",
   "text.graves.gui.cost": "Cost:",
   "text.graves.gui.teleport.cost": "Cost:",
-  "text.graves.gui.unlock_grave": "Unlock Grave",
+  "text.graves.gui.unlock_grave": "Pay for Access",
   "text.graves.gui.fetch": "Move grave to your location",
   "text.graves.gui.fetch_failed": "Couldn't move grave to your location!",
 

--- a/src/main/resources/data/universal_graves/lang/es_es.json
+++ b/src/main/resources/data/universal_graves/lang/es_es.json
@@ -8,6 +8,7 @@
   "text.graves.break_time_sign": "Se destruirá en",
   "text.graves.not_protected": "No protegida!",
   "text.graves.players_grave": "Tumba de %s",
+  "text.graves.admin_graves": "Todas las tumbas",
   "text.graves.gui_title": "Tus tumbas",
   "text.graves.no_longer_protected": "Tu tumba en %s (%s) que contiene %s ítem(s) ya no está protegida!",
   "text.graves.expired": "Tu tumba en %s (%s) que contenía %s ítem(s) ha expirado!",
@@ -18,6 +19,9 @@
   "text.graves.creation_failed_void": "La tumba no fue creada porque has muerto en el vacío!",
   "text.graves.creation_failed_pvp": "La tumba no fue creada porque un jugador te mató! Tus ítems fueron soltados en %s (%s)",
   "text.graves.creation_failed_claim": "La tumba no fue creada porque estabas en terreno protegido! Tus ítems fueron soltados en %s (%s)",
+  "text.graves.grave_unlock_payment.no_access": "No puedes pagar para acceder a esta tumba!",
+  "text.graves.grave_unlock_payment.accepted": "Has pagado el acceso a la tumba!",
+  "text.graves.grave_unlock_payment.failed": "No tienes recursos suficientes para acceder a la tumba! Necesitas: %s",
 
   "text.graves.damage_source_info": "Has sido dañado por: %s",
   "text.graves.damage_source_info.enabled": "Se activó la visualización de la fuente del próximo daño! Usa este comando otra vez para desactivarla.",
@@ -32,8 +36,10 @@
   "text.graves.gui.break_grave": "Destruir Tumba",
   "text.graves.gui.quick_pickup": "Coger Todos los Ítems",
   "text.graves.gui.teleport": "Teletransportar hacia la tumba",
-  "text.graves.gui.teleport.not_enough": "Recursos insuficientes!",
-  "text.graves.gui.cost": "Costo:",
+  "text.graves.gui.cost.not_enough": "Recursos insuficientes!",
+  "text.graves.gui.cost": "Coste:",
+  "text.graves.gui.teleport.cost": "Coste:",
+  "text.graves.gui.unlock_grave": "Pagar para acceder",
   "text.graves.gui.fetch": "Mover tumba hacia tu posición",
   "text.graves.gui.fetch_failed": "No se pudo mover la tumba hacia tu posición!",
 
@@ -48,6 +54,7 @@
   "item.universal_graves.grave_compass": "Brújula de Tumba",
   "block.universal_graves.grave": "Tumba",
   "block.universal_graves.visual_grave": "Lápida",
+  "block.universal_graves.container_grave": "Lápida",
 
   "gamerule.universal_graves:protection_time": "Tiempo de protección de la tumba contra otros jugadores",
   "gamerule.universal_graves:breaking_time": "Tiempo de expiración de la tumba",
@@ -55,5 +62,7 @@
   "text.graves.cost.level": "Niveles de Experiencia",
   "text.graves.cost.creative": "Creativo",
   "text.graves.cost.free": "Gratis",
-  "text.graves.cost.item": "Ítems"
+  "text.graves.cost.item": "Ítems",
+
+  "screen.graves.settings": "Ajustes de Universal Graves"
 }

--- a/src/test/java/eu/pb4/graves/config/BaseGsonUnlockCostTest.java
+++ b/src/test/java/eu/pb4/graves/config/BaseGsonUnlockCostTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BaseGsonUnlockCostTest {
     @BeforeAll
@@ -32,15 +31,13 @@ class BaseGsonUnlockCostTest {
                   "enchantment_cost_mode": "enchanted_stacks",
                   "minimum_cost": 2,
                   "owner_multiplier": 1.25,
-                  "non_owner_multiplier": 3.0,
-                  "allow_non_owner_paid_unlock": true
+                  "non_owner_multiplier": 3.0
                 }
                 """;
 
         var parsed = assertInstanceOf(DynamicLevelUnlockCost.class, gson.fromJson(input, GraveUnlockCost.class));
         assertEquals(3, parsed.stackDivisor());
         assertEquals(DynamicLevelUnlockCost.EnchantmentCostMode.ENCHANTED_STACKS, parsed.enchantmentCostMode());
-        assertTrue(parsed.allowNonOwnerPaidUnlock());
         assertEquals(JsonParser.parseString(input), JsonParser.parseString(gson.toJson(parsed, GraveUnlockCost.class)));
     }
 

--- a/src/test/java/eu/pb4/graves/config/BaseGsonUnlockCostTest.java
+++ b/src/test/java/eu/pb4/graves/config/BaseGsonUnlockCostTest.java
@@ -1,0 +1,57 @@
+package eu.pb4.graves.config;
+
+import com.google.gson.JsonParser;
+import eu.pb4.graves.other.DynamicLevelUnlockCost;
+import eu.pb4.graves.other.GenericCost;
+import eu.pb4.graves.other.GraveUnlockCost;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BaseGsonUnlockCostTest {
+    @BeforeAll
+    static void bootstrapMinecraft() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    void roundTripsDynamicUnlockCost() {
+        var gson = BaseGson.getGson(RegistryAccess.EMPTY);
+        var input = """
+                {
+                  "type": "dynamic_level",
+                  "stack_divisor": 3,
+                  "enchantment_divisor": 4,
+                  "enchantment_cost_mode": "enchanted_stacks",
+                  "minimum_cost": 2,
+                  "owner_multiplier": 1.25,
+                  "non_owner_multiplier": 3.0,
+                  "allow_non_owner_paid_unlock": true
+                }
+                """;
+
+        var parsed = assertInstanceOf(DynamicLevelUnlockCost.class, gson.fromJson(input, GraveUnlockCost.class));
+        assertEquals(3, parsed.stackDivisor());
+        assertEquals(DynamicLevelUnlockCost.EnchantmentCostMode.ENCHANTED_STACKS, parsed.enchantmentCostMode());
+        assertTrue(parsed.allowNonOwnerPaidUnlock());
+        assertEquals(JsonParser.parseString(input), JsonParser.parseString(gson.toJson(parsed, GraveUnlockCost.class)));
+    }
+
+    @Test
+    void preservesLegacyStaticCostShape() {
+        var gson = BaseGson.getGson(RegistryAccess.EMPTY);
+        var input = "{\"type\":\"level\",\"count\":7}";
+
+        var parsed = assertInstanceOf(GraveUnlockCost.Static.class, gson.fromJson(input, GraveUnlockCost.class));
+        assertEquals(GenericCost.Type.LEVEL, parsed.cost().type());
+        assertEquals(7, parsed.cost().count());
+        assertEquals(JsonParser.parseString(input), JsonParser.parseString(gson.toJson(parsed, GraveUnlockCost.class)));
+    }
+}

--- a/src/test/java/eu/pb4/graves/other/DynamicLevelUnlockCostTest.java
+++ b/src/test/java/eu/pb4/graves/other/DynamicLevelUnlockCostTest.java
@@ -1,0 +1,68 @@
+package eu.pb4.graves.other;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DynamicLevelUnlockCostTest {
+    private static final DynamicLevelUnlockCost COST = new DynamicLevelUnlockCost(
+            3, 4, DynamicLevelUnlockCost.EnchantmentCostMode.LEVELS, 1, 1, 1.5, true
+    );
+
+    @Test
+    void combinesCompatibleStacksUsingTheirMaximumStackSize() {
+        assertEquals(1, count(new Stack("cobblestone", "", 32, 64), new Stack("cobblestone", "", 20, 64)));
+        assertEquals(2, count(new Stack("cobblestone", "", 64, 64), new Stack("cobblestone", "", 6, 64)));
+        assertEquals(2, count(new Stack("ender_pearl", "", 16, 16), new Stack("ender_pearl", "", 5, 16)));
+        assertEquals(2, count(new Stack("iron_pickaxe", "", 1, 1), new Stack("iron_pickaxe", "", 1, 1)));
+    }
+
+    @Test
+    void keepsStacksWithDifferentComponentsSeparate() {
+        assertEquals(2, count(new Stack("cobblestone", "", 32, 64), new Stack("cobblestone", "named", 20, 64)));
+    }
+
+    @Test
+    void appliesDivisorsMinimumAndCeilingMultiplier() {
+        assertEquals(4, COST.calculateFinalCost(6, 8, true));
+        assertEquals(6, COST.calculateFinalCost(6, 8, false));
+        assertEquals(1, COST.calculateFinalCost(0, 0, true));
+        assertEquals(2, COST.calculateFinalCost(0, 0, false));
+    }
+
+    @Test
+    void sanitizesInvalidConfigurationValues() {
+        var cost = new DynamicLevelUnlockCost(0, -2, null, -1, -4, Double.NaN, false);
+
+        assertEquals(1, cost.stackDivisor());
+        assertEquals(1, cost.enchantmentDivisor());
+        assertEquals(DynamicLevelUnlockCost.EnchantmentCostMode.LEVELS, cost.enchantmentCostMode());
+        assertEquals(0, cost.minimumCost());
+        assertEquals(0, cost.ownerMultiplier());
+        assertEquals(0, cost.nonOwnerMultiplier());
+    }
+
+    @Test
+    void parsesEnchantmentModesAndFallsBackToLevels() {
+        assertEquals(DynamicLevelUnlockCost.EnchantmentCostMode.ENCHANTED_STACKS,
+                DynamicLevelUnlockCost.EnchantmentCostMode.fromConfig("enchanted_stacks"));
+        assertEquals(DynamicLevelUnlockCost.EnchantmentCostMode.LEVELS,
+                DynamicLevelUnlockCost.EnchantmentCostMode.fromConfig("unknown"));
+    }
+
+    @Test
+    void clampsOverflowToTheMaximumSupportedLevelCost() {
+        assertEquals(Integer.MAX_VALUE, COST.calculateFinalCost(Long.MAX_VALUE, Long.MAX_VALUE, false));
+    }
+
+    private static long count(Stack... stacks) {
+        return DynamicLevelUnlockCost.countEquivalentStacks(
+                List.of(stacks), Stack::count, Stack::maxStackSize,
+                (first, second) -> first.item.equals(second.item) && first.components.equals(second.components)
+        );
+    }
+
+    private record Stack(String item, String components, int count, int maxStackSize) {}
+}

--- a/src/test/java/eu/pb4/graves/other/DynamicLevelUnlockCostTest.java
+++ b/src/test/java/eu/pb4/graves/other/DynamicLevelUnlockCostTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class DynamicLevelUnlockCostTest {
     private static final DynamicLevelUnlockCost COST = new DynamicLevelUnlockCost(
-            3, 4, DynamicLevelUnlockCost.EnchantmentCostMode.LEVELS, 1, 1, 1.5, true
+            3, 4, DynamicLevelUnlockCost.EnchantmentCostMode.LEVELS, 1, 1, 1.5
     );
 
     @Test
@@ -25,16 +25,17 @@ class DynamicLevelUnlockCostTest {
     }
 
     @Test
-    void appliesDivisorsMinimumAndCeilingMultiplier() {
+    void appliesDivisorsMinimumAndFloorMultiplier() {
+        assertEquals(4, COST.calculateBaseCost(6, 8));
         assertEquals(4, COST.calculateFinalCost(6, 8, true));
         assertEquals(6, COST.calculateFinalCost(6, 8, false));
         assertEquals(1, COST.calculateFinalCost(0, 0, true));
-        assertEquals(2, COST.calculateFinalCost(0, 0, false));
+        assertEquals(1, COST.calculateFinalCost(0, 0, false));
     }
 
     @Test
     void sanitizesInvalidConfigurationValues() {
-        var cost = new DynamicLevelUnlockCost(0, -2, null, -1, -4, Double.NaN, false);
+        var cost = new DynamicLevelUnlockCost(0, -2, null, -1, -4, Double.NaN);
 
         assertEquals(1, cost.stackDivisor());
         assertEquals(1, cost.enchantmentDivisor());
@@ -54,6 +55,7 @@ class DynamicLevelUnlockCostTest {
 
     @Test
     void clampsOverflowToTheMaximumSupportedLevelCost() {
+        assertEquals(Integer.MAX_VALUE, COST.calculateBaseCost(Long.MAX_VALUE, Long.MAX_VALUE));
         assertEquals(Integer.MAX_VALUE, COST.calculateFinalCost(Long.MAX_VALUE, Long.MAX_VALUE, false));
     }
 


### PR DESCRIPTION
## Summary
- add an optional `dynamic_level` grave unlock cost based on equivalent stacks and enchantments
- calculate owner/non-owner quotes from the grave's current remaining contents, with configurable divisors, minimum, modes, and multipliers
- persist paid access per player without globally removing grave protection
- preserve the existing JSON shape and global behavior of static `free`, `creative`, `item`, and `level` costs
- allow eligible non-owners to open the locked grave UI and pay, while preventing item removal, protection removal, and grave breaking before payment

## Implementation notes
- grave-specific pricing is separated from the generic cost abstraction used by teleportation
- stack grouping uses `ItemStack.isSameItemSameComponents` and each group's normal maximum stack size
- multiplier results are rounded up
- paid UUIDs use a separate NBT field from the existing protection allow-list
- quotes are recalculated when the payment action runs, so removed contents reduce later prices

## Validation
- added unit tests for grouping, component-sensitive compatibility, formulas, rounding, validation, overflow, configuration round-trips, and legacy static JSON compatibility
- `./gradlew build`

Closes #239
